### PR TITLE
update tests with epoch time comparisons, and update parent pom version

### DIFF
--- a/dcc-download-server/src/test/java/org/icgc/dcc/download/server/fs/AbstractFileSystemViewTest.java
+++ b/dcc-download-server/src/test/java/org/icgc/dcc/download/server/fs/AbstractFileSystemViewTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.icgc.dcc.common.hadoop.fs.FileSystems.getDefaultLocalFileSystem;
 import static org.icgc.dcc.common.hadoop.fs.HadoopUtils.lsDir;
 import static org.icgc.dcc.download.server.fs.AbstractFileSystemView.resolveCurrentRelease;
+import static org.icgc.dcc.download.server.utils.DateUtils.isEpochsEqualUpToSecondsDigits;
 import static org.mockito.Mockito.mock;
 
 import java.io.File;
@@ -118,7 +119,7 @@ public class AbstractFileSystemViewTest extends AbstractTest {
     val fileAttributes = getFileAttributes(srcFile);
     val creationTime = fileAttributes.creationTime();
     log.info("{}", creationTime);
-    assertThat(actualDate).isEqualTo(creationTime.toMillis());
+    assertThat(isEpochsEqualUpToSecondsDigits(actualDate, creationTime.toMillis())).isTrue();
   }
 
   @SneakyThrows

--- a/dcc-download-server/src/test/java/org/icgc/dcc/download/server/fs/DownloadFilesReaderTest.java
+++ b/dcc-download-server/src/test/java/org/icgc/dcc/download/server/fs/DownloadFilesReaderTest.java
@@ -1,24 +1,25 @@
 /*
- * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.                             
- *                                                                                                               
+ * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.
+ *
  * This program and the accompanying materials are made available under the terms of the GNU Public License v3.0.
- * You should have received a copy of the GNU General Public License along with                                  
- * this program. If not, see <http://www.gnu.org/licenses/>.                                                     
- *                                                                                                               
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY                           
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES                          
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT                           
- * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                                
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED                          
- * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;                               
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER                              
- * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN                         
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.icgc.dcc.download.server.fs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.icgc.dcc.common.hadoop.fs.FileSystems.getDefaultLocalFileSystem;
+import static org.icgc.dcc.download.server.utils.DateUtils.isEpochsEqualUpToSecondsDigits;
 
 import java.io.File;
 import java.util.Map;
@@ -38,78 +39,80 @@ import lombok.val;
 
 public class DownloadFilesReaderTest extends AbstractFsTest {
 
-  FileSystem fileSystem = getDefaultLocalFileSystem();
-  DownloadFilesReader downloadFilesReader;
-  PathResolver pathResolver;
+    FileSystem fileSystem = getDefaultLocalFileSystem();
+    DownloadFilesReader downloadFilesReader;
+    PathResolver pathResolver;
 
-  @Override
-  public void setUp() {
-    super.setUp();
-    val properties = new Properties.JobProperties();
-    properties.setInputDir(workingDir.getAbsolutePath());
-    pathResolver = new PathResolver(properties);
-    downloadFilesReader = new DownloadFilesReader(fileSystem, pathResolver);
-  }
-
-  @Test
-  public void testCreateReleaseCache() throws Exception {
-    val releaseTable = downloadFilesReader.createReleaseCache(getReleasePath());
-    assertRelease21(releaseTable);
-  }
-
-  @Test
-  public void testCreateProjectDonors() throws Exception {
-    val projectDonors = DownloadFilesReader.createProjectDonors(DownloadFsTests.createDonorFileTypesTable());
-    assertThat(projectDonors.size()).isEqualTo(3);
-    assertThat(projectDonors.get("TST1-CA")).containsOnly("DO001", "DO002");
-    assertThat(projectDonors.get("TST2-CA")).containsOnly("DO003");
-
-  }
-
-  @Test
-  public void testGetReleaseTimes() throws Exception {
-    val releaseTimes = downloadFilesReader.getReleaseTimes();
-    assertThat(releaseTimes).hasSize(1);
-    assertThat(releaseTimes.get("release_21")).isEqualTo(getModificationTime("release_21"));
-  }
-
-  @Test
-  public void testGetReleaseProjectDonors() throws Exception {
-    val releaseProjects = downloadFilesReader.getReleaseProjectDonors();
-    assertThat(releaseProjects.size()).isEqualTo(1);
-    val projectDonors = releaseProjects.get("release_21");
-    assertThat(projectDonors.size()).isEqualTo(4);
-    assertThat(projectDonors.get("TST1-CA")).containsOnly("DO001", "DO002");
-    assertThat(projectDonors.get("TST2-CA")).containsOnly("DO003", "DO004");
-  }
-
-  @Test
-  public void testCreateReleaseCacheString() throws Exception {
-    val releaseTable = downloadFilesReader.createReleaseCache("release_21");
-    assertRelease21(releaseTable);
-  }
-
-  private void assertRelease21(Table<String, DownloadDataType, DataTypeFile> releaseTable) {
-    assertThat(releaseTable.size()).isEqualTo(36);
-    assertDonor(releaseTable.row("DO001"), (short) 0, 10);
-    assertDonor(releaseTable.row("DO002"), (short) 0, 10);
-    assertDonor(releaseTable.row("DO003"), (short) 1, 8);
-    assertDonor(releaseTable.row("DO004"), (short) 1, 8);
-  }
-
-  private Path getReleasePath() {
-    val releaseDir = new File(workingDir, "release_21").getAbsolutePath();
-
-    return new Path(releaseDir);
-  }
-
-  private void assertDonor(Map<DownloadDataType, DataTypeFile> row, Short expectedPartFile, int expectedDataTypes) {
-    assertThat(row).hasSize(expectedDataTypes);
-    for (val dataTypeFile : row.values()) {
-      val partFiles = dataTypeFile.getPartFileIndices();
-      assertThat(partFiles).hasSize(1);
-      assertThat(partFiles.get(0)).isEqualTo(expectedPartFile);
+    @Override
+    public void setUp() {
+        super.setUp();
+        val properties = new Properties.JobProperties();
+        properties.setInputDir(workingDir.getAbsolutePath());
+        pathResolver = new PathResolver(properties);
+        downloadFilesReader = new DownloadFilesReader(fileSystem, pathResolver);
     }
-  }
+
+    @Test
+    public void testCreateReleaseCache() throws Exception {
+        val releaseTable = downloadFilesReader.createReleaseCache(getReleasePath());
+        assertRelease21(releaseTable);
+    }
+
+    @Test
+    public void testCreateProjectDonors() throws Exception {
+        val projectDonors = DownloadFilesReader.createProjectDonors(DownloadFsTests.createDonorFileTypesTable());
+        assertThat(projectDonors.size()).isEqualTo(3);
+        assertThat(projectDonors.get("TST1-CA")).containsOnly("DO001", "DO002");
+        assertThat(projectDonors.get("TST2-CA")).containsOnly("DO003");
+
+    }
+
+    @Test
+    public void testGetReleaseTimes() throws Exception {
+        val releaseTimes = downloadFilesReader.getReleaseTimes();
+        assertThat(releaseTimes).hasSize(1);
+        assertThat(
+                isEpochsEqualUpToSecondsDigits(releaseTimes.get("release_21"), getModificationTime("release_21"))
+        ).isTrue();
+    }
+
+    @Test
+    public void testGetReleaseProjectDonors() throws Exception {
+        val releaseProjects = downloadFilesReader.getReleaseProjectDonors();
+        assertThat(releaseProjects.size()).isEqualTo(1);
+        val projectDonors = releaseProjects.get("release_21");
+        assertThat(projectDonors.size()).isEqualTo(4);
+        assertThat(projectDonors.get("TST1-CA")).containsOnly("DO001", "DO002");
+        assertThat(projectDonors.get("TST2-CA")).containsOnly("DO003", "DO004");
+    }
+
+    @Test
+    public void testCreateReleaseCacheString() throws Exception {
+        val releaseTable = downloadFilesReader.createReleaseCache("release_21");
+        assertRelease21(releaseTable);
+    }
+
+    private void assertRelease21(Table<String, DownloadDataType, DataTypeFile> releaseTable) {
+        assertThat(releaseTable.size()).isEqualTo(36);
+        assertDonor(releaseTable.row("DO001"), (short) 0, 10);
+        assertDonor(releaseTable.row("DO002"), (short) 0, 10);
+        assertDonor(releaseTable.row("DO003"), (short) 1, 8);
+        assertDonor(releaseTable.row("DO004"), (short) 1, 8);
+    }
+
+    private Path getReleasePath() {
+        val releaseDir = new File(workingDir, "release_21").getAbsolutePath();
+
+        return new Path(releaseDir);
+    }
+
+    private void assertDonor(Map<DownloadDataType, DataTypeFile> row, Short expectedPartFile, int expectedDataTypes) {
+        assertThat(row).hasSize(expectedDataTypes);
+        for (val dataTypeFile : row.values()) {
+            val partFiles = dataTypeFile.getPartFileIndices();
+            assertThat(partFiles).hasSize(1);
+            assertThat(partFiles.get(0)).isEqualTo(expectedPartFile);
+        }
+    }
 
 }

--- a/dcc-download-server/src/test/java/org/icgc/dcc/download/server/fs/DownloadFilesReaderTest.java
+++ b/dcc-download-server/src/test/java/org/icgc/dcc/download/server/fs/DownloadFilesReaderTest.java
@@ -1,18 +1,18 @@
 /*
- * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.
- *
+ * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.                             
+ *                                                                                                               
  * This program and the accompanying materials are made available under the terms of the GNU Public License v3.0.
- * You should have received a copy of the GNU General Public License along with
- * this program. If not, see <http://www.gnu.org/licenses/>.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
- * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
- * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
- * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * You should have received a copy of the GNU General Public License along with                                  
+ * this program. If not, see <http://www.gnu.org/licenses/>.                                                     
+ *                                                                                                               
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY                           
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES                          
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT                           
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                                
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED                          
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;                               
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER                              
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN                         
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.icgc.dcc.download.server.fs;

--- a/dcc-download-server/src/test/java/org/icgc/dcc/download/server/utils/AbstractFsTest.java
+++ b/dcc-download-server/src/test/java/org/icgc/dcc/download/server/utils/AbstractFsTest.java
@@ -19,6 +19,7 @@ package org.icgc.dcc.download.server.utils;
 
 import static com.google.common.base.Preconditions.checkState;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.icgc.dcc.download.server.utils.DateUtils.isEpochsEqualUpToSecondsDigits;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -79,7 +80,7 @@ public abstract class AbstractFsTest extends AbstractTest {
   private static void assertDownloadFiles(DownloadFile actualFile, DownloadFile expectedFile) {
     assertThat(actualFile.getName()).isEqualTo(expectedFile.getName());
     assertThat(actualFile.getType()).isEqualTo(expectedFile.getType());
-    assertThat(actualFile.getDate()).isEqualTo(expectedFile.getDate());
+    assertThat(isEpochsEqualUpToSecondsDigits(actualFile.getDate(), expectedFile.getDate())).isTrue();
     assertThat(actualFile.getSize()).isEqualTo(expectedFile.getSize());
   }
 

--- a/dcc-download-server/src/test/java/org/icgc/dcc/download/server/utils/DateUtils.java
+++ b/dcc-download-server/src/test/java/org/icgc/dcc/download/server/utils/DateUtils.java
@@ -1,0 +1,26 @@
+package org.icgc.dcc.download.server.utils;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class DateUtils {
+    /**
+     * This method checks if two epoch times are equal up to seconds digits by diving both by a 1000 (i.e. remove
+     * milliseconds digits) and check for equality. Note that this method does not round the epoch times, since
+     * both numbers should have the same digits except for the last three.
+     *
+     * The use case for this method is for tests that assert epoch time equality, but the milliseconds digits are not
+     * available for both numbers. Primary example is the Hadoop-common library methods which return epoch times with
+     * no millisecond digits but Java-8 FileSystem methods return epoch times with milliseconds.
+     *
+     * Java 8 (OpenJDK) FS method returns   :1624388695494L
+     * Hadoop FS method returns             :1624388695000L
+     *
+     * @param epochTimeA
+     * @param epochTimeB
+     * @return
+     */
+    public static Boolean isEpochsEqualUpToSecondsDigits(Long epochTimeA, Long epochTimeB) {
+        return epochTimeA / 1000 == epochTimeB / 1000;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
   <parent>
     <groupId>org.icgc.dcc</groupId>
     <artifactId>dcc-parent</artifactId>
-    <version>35</version>
+    <version>37</version>
   </parent>
 
   <artifactId>dcc-download</artifactId>


### PR DESCRIPTION
pending release of parent-pom

changes:
- update parent pom version
- Fix tests that were comparing dates and failing. These tests had one epoch time missing milliseconds digits and the other had them.